### PR TITLE
widthTable の lint 修正

### DIFF
--- a/src/app/prefecturePage.tsx
+++ b/src/app/prefecturePage.tsx
@@ -175,7 +175,7 @@ export function PrefecturePage() {
       </div>
     );
   }
-  function widthTable(w: number, items: []) {
+  function widthTable(w: number, items: JSX.Element[]):JSX.Element[] {
     const h = Math.ceil(items.length / w);
     const li = [];
     var key = 0;


### PR DESCRIPTION
widthTable の引数・返り値の型を適切に指定していないため lint エラーが出ています。これを解決します。