### PR TITLE
highcharts の依存関係を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@testing-library/user-event": "14",
     "dotenv": "^16.4.5",
+    "highcharts": "^11.4.3",
     "highcharts-react-official": "^3.2.1",
     "next": "14.2.3",
     "react": "^18",


### PR DESCRIPTION
デプロイ時に Highcharts が依存関係に読み込まれておらずエラーが出ています．その修正です．